### PR TITLE
Fixing 2 CMake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5...3.31.5)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules)
 
@@ -163,7 +163,7 @@ endif()
 
 add_custom_target(travis_doc)
 add_custom_command(TARGET travis_doc
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/travis-doxygen.sh)
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/travis-doxygen.sh POST_BUILD)
 
 if(RAPIDJSON_BUILD_EXAMPLES)
     add_subdirectory(example)


### PR DESCRIPTION
There are 2 warnings, one of them relates to versioning, and one of them is for policy CMP0175.
```
CMake Deprecation Warning at build-dev-gcc/_deps/rapidjson-src/CMakeLists.txt:1 (CMAKE_MINIMUM_REQUIRED):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


CMake Warning (dev) at build-dev-gcc/_deps/rapidjson-src/CMakeLists.txt:165 (add_custom_command):
  Exactly one of PRE_BUILD, PRE_LINK, or POST_BUILD must be given.  Assuming
  POST_BUILD to preserve backward compatibility.

  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
```


```
cmake --help-policy CMP0175
CMP0175
-------

.. versionadded:: 3.31

``add_custom_command()`` rejects invalid arguments.

CMake 3.30 and earlier silently ignored unsupported keywords and missing or
invalid arguments for the different forms of the ``add_custom_command()``
command. CMake 3.31 implements more rigorous argument checking and will flag
invalid or missing arguments as errors.

The ``OLD`` behavior of this policy will accept the same invalid keywords or
arguments as CMake 3.30 and earlier. The ``NEW`` behavior will flag the
following as errors that previously went unreported:

* The ``OUTPUT`` form does not accept ``PRE_BUILD``, ``PRE_LINK``, or
  ``POST_BUILD`` keywords.
* When the ``APPEND`` keyword is given, the ``OUTPUT`` form also does not
  accept ``BYPRODUCTS``, ``COMMAND_EXPAND_LISTS``, ``DEPENDS_EXPLICIT_ONLY``,
  ``DEPFILE``, ``JOB_POOL``, ``JOB_SERVER_AWARE``, ``USES_TERMINAL``, or
  ``VERBATIM`` keywords.
* The ``TARGET`` form requires exactly one of ``PRE_BUILD``, ``PRE_LINK``, or
  ``POST_BUILD`` to be given.  Previously, if none were given, ``POST_BUILD``
  was assumed, or if multiple keywords were given, the last one was used.
* The ``TARGET`` form does not accept ``DEPENDS``, ``DEPENDS_EXPLICIT_ONLY``,
  ``DEPFILE``, ``IMPLICIT_DEPENDS``, ``MAIN_DEPENDENCY``, ``JOB_POOL``, or
  ``JOB_SERVER_AWARE`` keywords.
* The ``TARGET`` form now requires at least one ``COMMAND`` to be given.
* If a keyword expects a value to be given after it, but no value is provided,
  that was previously treated as though the keyword was not given at all.
* The ``COMMENT`` keyword expects exactly one value after it.  If multiple
  values are given, or if the ``COMMENT`` keyword is given more than once,
  this is an error.

This policy was introduced in CMake version 3.31.
It may be set by ``cmake_policy()`` or ``cmake_minimum_required()``.
If it is not set, CMake warns, and uses ``OLD`` behavior.

.. note::
  The ``OLD`` behavior of a policy is
  ``deprecated by definition``
  and may be removed in a future version of CMake.
```